### PR TITLE
Upping color contrast on the warning badges

### DIFF
--- a/docs/badges/badges-contrast.html
+++ b/docs/badges/badges-contrast.html
@@ -71,7 +71,7 @@
         .badge.low-contrast::before {
             content: attr(data-contrast);
             position: absolute;
-            background: red;
+            background: #ee0000;
             color: white;
             font-weight: bold;
             border-radius: 2px;


### PR DESCRIPTION
The badges to show low contrast on the page actually had low contrast themselves!
This was reported by Kilian https://twitter.com/kilianvalkhof/status/1405444099675729922
This PR fixes it.