### PR TITLE
Marking the repo as archived and redirecting demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
+⚠️ **THIS REPOSITORY IS NOT MAINTAINED ANYMORE AND ALL DEMOS HAVE MOVED TO [THE DEMOS REPOSITORY](https://github.com/MicrosoftEdge/Demos)** ⚠️
+
 # Microsoft Edge DevTools Samples
 
 A collection of samples for Edge Developer Tools.
-
 
 ## Contributing
 

--- a/docs/a11y-testing/page-with-errors.html
+++ b/docs/a11y-testing/page-with-errors.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-a11y-testing/">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Demo page with accessibility issues</title>

--- a/docs/badges/badges-contrast.html
+++ b/docs/badges/badges-contrast.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-contrast-bugfix/">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Testing all badges in DevTools for contrast issues</title>

--- a/docs/console/dom-examples.html
+++ b/docs/console/dom-examples.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/dom-examples.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Interacting with the DOM</title>

--- a/docs/console/error-assert.html
+++ b/docs/console/error-assert.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/error-assert.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Creating error reports and assertions in Console</title>

--- a/docs/console/error.html
+++ b/docs/console/error.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/error.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>JavaScript error reported in the Console tool</title>

--- a/docs/console/logging-demo.html
+++ b/docs/console/logging-demo.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/logging-demo.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Console messages examples: log, info, error and warn</title>

--- a/docs/console/logging-examples.html
+++ b/docs/console/logging-examples.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/logging-examples.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Console messages examples: log, info, error and warn</title>

--- a/docs/console/logging-types.html
+++ b/docs/console/logging-types.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/logging-types.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Console messages examples: logging different types</title>

--- a/docs/console/logging-with-groups.html
+++ b/docs/console/logging-with-groups.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/logging-with-groups.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Console messages examples: grouping logs</title>

--- a/docs/console/logging-with-specifiers.html
+++ b/docs/console/logging-with-specifiers.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/logging-with-specifiers.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Console messages examples: Logging with specifiers</title>

--- a/docs/console/logging-with-table.html
+++ b/docs/console/logging-with-table.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/logging-with-table.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Console messages examples: Using table</title>

--- a/docs/console/mousemove-no-log.html
+++ b/docs/console/mousemove-no-log.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/mousemove-no-log.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Mouse movement without logging</title>

--- a/docs/console/mousemove.html
+++ b/docs/console/mousemove.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/mousemove.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Console messages examples: Using table</title>

--- a/docs/console/network-error-fixed.html
+++ b/docs/console/network-error-fixed.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/network-error-fixed.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fixed network error reported in Console</title>

--- a/docs/console/network-error-reported.html
+++ b/docs/console/network-error-reported.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/network-error-reported.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Network error reporting in Console and UI</title>

--- a/docs/console/network-error.html
+++ b/docs/console/network-error.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/network-error.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Network error reported in Console</title>

--- a/docs/console/trace.html
+++ b/docs/console/trace.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-console/trace.html">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Creating traces in Console</title>

--- a/docs/inspector/inspector-demo.html
+++ b/docs/inspector/inspector-demo.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-inspect/">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Inspector Demonstration</title>

--- a/docs/whats-new/89/target-css-demo.html
+++ b/docs/whats-new/89/target-css-demo.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <head>
+  <meta http-equiv="Refresh" content="0; URL=https://microsoftedge.github.io/Demos/devtools-target-pseudo/">
   <meta charset="utf-8">
   <title>CSS :target demo for What's New in DevTools (Microsoft Edge 89)</title>
   <link rel="shortcut icon" type="image/ico" href="favicon_io/favicon.ico"/>


### PR DESCRIPTION
This PR adds a banner to the README to tell visitors that the repo is archived and not maintained.
It also adds http redirects to all the demos that have already been moved to the new [Demos](https://github.com/MicrosoftEdge/Demos) repo.

Next step after this PR is merged is to actually marked the repo as archived in GitHub. I'd vote for keeping it for posterity, we don't need to delete it.